### PR TITLE
feat: ensure idempotency for all generated files in pipeline

### DIFF
--- a/ai_tool/src/pipeline/stage_component.py
+++ b/ai_tool/src/pipeline/stage_component.py
@@ -171,6 +171,11 @@ async def generate_detailed_component(baustein_id: str, baustein_title: str, zie
     sanitized_zielobjekt_name = sanitize_filename(zielobjekt_name)
     sanitized_baustein_id = sanitize_filename(baustein_id)
     output_filename = f"{sanitized_zielobjekt_name}_{sanitized_baustein_id}-enhanced-component.json"
+    output_path = os.path.join(output_dir, output_filename)
+
+    if os.path.exists(output_path) and not app_config.overwrite_temp_files:
+        logger.info(f"Enhanced component already exists at {output_path} and OVERWRITE_TEMP_FILES is false. Skipping.")
+        return
 
     if not os.path.exists(profile_path):
         logger.warning(f"Profile not found for {baustein_id} at {profile_path}. Skipping detailed component.")
@@ -360,7 +365,6 @@ async def generate_detailed_component(baustein_id: str, baustein_title: str, zie
         }
     }
 
-    output_path = os.path.join(output_dir, output_filename)
     write_json_file(output_path, component_definition)
 
     validate_oscal(output_path, OSCAL_COMPONENT_SCHEMA_PATH)
@@ -371,6 +375,11 @@ def generate_minimal_component(baustein_id: str, baustein_title: str, zielobjekt
     sanitized_zielobjekt_name = sanitize_filename(zielobjekt_name)
     sanitized_baustein_id = sanitize_filename(baustein_id)
     output_filename = f"{sanitized_zielobjekt_name}_{sanitized_baustein_id}-component.json"
+    output_path = os.path.join(output_dir, output_filename)
+
+    if os.path.exists(output_path) and not app_config.overwrite_temp_files:
+        logger.info(f"Minimal component already exists at {output_path} and OVERWRITE_TEMP_FILES is false. Skipping.")
+        return
 
     if not os.path.exists(profile_path):
         logger.warning(f"Profile not found for {baustein_id} at {profile_path}. Skipping minimal component.")
@@ -413,7 +422,6 @@ def generate_minimal_component(baustein_id: str, baustein_title: str, zielobjekt
         }
     }
 
-    output_path = os.path.join(output_dir, output_filename)
     write_json_file(output_path, component_definition)
 
     validate_oscal(output_path, OSCAL_COMPONENT_SCHEMA_PATH)
@@ -559,6 +567,13 @@ def generate_zielobjekt_components():
             continue
 
         sanitized_name = sanitize_filename(zielobjekt_name)
+        output_filename = f"{sanitized_name}-component.json"
+        output_path = os.path.join(SDT_COMPONENTS_GPP_DIR, output_filename)
+
+        if os.path.exists(output_path) and not app_config.overwrite_temp_files:
+            logger.info(f"Zielobjekt component already exists at {output_path} and OVERWRITE_TEMP_FILES is false. Skipping.")
+            continue
+
         profile_filename = f"{sanitized_name}_profile.json"
         profile_path = os.path.join(SDT_PROFILES_DIR, profile_filename)
 
@@ -604,8 +619,6 @@ def generate_zielobjekt_components():
             }
         }
 
-        output_filename = f"{sanitized_name}-component.json"
-        output_path = os.path.join(SDT_COMPONENTS_GPP_DIR, output_filename)
         write_json_file(output_path, component_definition)
         validate_oscal(output_path, OSCAL_COMPONENT_SCHEMA_PATH)
         logger.info(f"Generated component for Zielobjekt: {zielobjekt_name}")

--- a/ai_tool/src/pipeline/stage_profiles.py
+++ b/ai_tool/src/pipeline/stage_profiles.py
@@ -11,6 +11,7 @@ import uuid
 import logging
 from datetime import datetime, timezone
 
+from config import app_config
 from constants import (
     ZIELOBJEKT_CONTROLS_JSON_PATH,
     SDT_PROFILES_DIR,
@@ -98,6 +99,10 @@ def run_stage_profiles():
         sanitized_name = sanitize_filename(zielobjekt_name)
         output_filename = f"{sanitized_name}_profile.json"
         output_path = os.path.join(output_dir, output_filename)
+
+        if os.path.exists(output_path) and not app_config.overwrite_temp_files:
+            logger.info(f"Profile already exists at {output_path} and OVERWRITE_TEMP_FILES is false. Skipping.")
+            continue
 
         write_json_file(output_path, profile)
         logger.info(f"Generated OSCAL profile for {zielobjekt_name} at {output_path}")

--- a/ai_tool/tests/test_stage_component_enhanced.py
+++ b/ai_tool/tests/test_stage_component_enhanced.py
@@ -27,7 +27,11 @@ class TestStageComponentEnhanced(unittest.IsolatedAsyncioTestCase):
     @patch('pipeline.stage_component.validate_oscal')
     @patch('pipeline.stage_component.read_csv_file')
     @patch('os.path.exists')
-    async def test_generate_detailed_component_enhanced(self, mock_exists, mock_read_csv, mock_validate_oscal, mock_write_json, mock_read_json, mock_read_text):
+    @patch('pipeline.stage_component.app_config')
+    async def test_generate_detailed_component_enhanced(self, mock_app_config, mock_exists, mock_read_csv, mock_validate_oscal, mock_write_json, mock_read_json, mock_read_text):
+        # Mock app config for overwrite_temp_files
+        mock_app_config.overwrite_temp_files = True
+
         # Mock file existence
         mock_exists.return_value = True
 


### PR DESCRIPTION
This submission updates the OSCAL pipeline generation stages (`stage_component.py` and `stage_profiles.py`) to fully support idempotency. It checks if the target output file already exists and skips the costly AI generation step if `app_config.overwrite_temp_files` is set to `False`. This addresses the user's request to "check for idempotency for every file". Tests were updated and successfully ran.

---
*PR created automatically by Jules for task [17615841812744726759](https://jules.google.com/task/17615841812744726759) started by @Christoph-Puppe-Work*